### PR TITLE
Check and clean up orphaned kex pods every time

### DIFF
--- a/kex
+++ b/kex
@@ -86,6 +86,15 @@ def run_pod_session(app_name, command, kubectl_options)
     puts "Deleting pod #{pod_name} ..."
     system("kubectl #{kubectl_options} delete pod #{pod_name}")
   end
+
+  cleanup_orphaned_pods(kubectl_options)
+end
+
+def cleanup_orphaned_pods(kubectl_options)
+  pods = %x[kubectl #{kubectl_options} get pod -l heritage=kex --field-selector=status.phase!=Running -o custom-columns=":metadata.name" --no-headers]
+  return if pods.empty?
+  puts "Deleting existing orphaned kex pods ..."
+  system(%[kubectl #{kubectl_options} delete pods #{pods.gsub("\n", " ")}])
 end
 
 # Create pod with given spec Hash and kubectl options string
@@ -127,7 +136,8 @@ def create_pod_spec_from_original(pod_spec, app_name)
     },
     "spec" => {
       "containers" => patch_containers_for_run(pod_spec["spec"]["containers"], app_name),
-      "volumes" => pod_spec["spec"]["volumes"]
+      "volumes" => pod_spec["spec"]["volumes"],
+      "restartPolicy" => "Never"
     }
   }
 end


### PR DESCRIPTION
It seems that the signal from the parent process is not transmitted to the command(a child process) specified by the `script` command (Probably because the process become a session leader process).
For example, if an ssh connection is killed unexpectedly it will be in that way.
(HUP signal will not be propagated to the kex process)

As a result, the kex script process as a child of `script` command disappears without executing the ensure block and the kex pod continues to loop sleep in the cluster without being deleted.

Although I tried various methods, I judged that it is difficult to make sure that the signal is processed.
Therefore, I decided to clean up every time we run kex.